### PR TITLE
- Fixed problem with Sqlite disposing inmemory databases when connect…

### DIFF
--- a/src/ResourceProvisioning.Broker.Application/Commands/Environment/CreateEnvironmentCommandHandler.cs
+++ b/src/ResourceProvisioning.Broker.Application/Commands/Environment/CreateEnvironmentCommandHandler.cs
@@ -18,12 +18,11 @@ namespace ResourceProvisioning.Broker.Application.Commands.Environment
 			_controlPlaneService = controlPlaneService ?? throw new ArgumentNullException(nameof(controlPlaneService));
 		}
 
-		public override async Task<IProvisioningResponse> Handle(CreateEnvironmentCommand command, CancellationToken cancellationToken)
+		public override async Task<IProvisioningResponse> Handle(CreateEnvironmentCommand command, CancellationToken cancellationToken = default)
 		{
-			//TODO: Re-enable CreateEnvironmentCommandHandler logic once db is working. (Ch2943)
-			//var aggregate = await _controlPlaneService.AddEnvironmentAsync(command.DesiredState);
+			var aggregate = await _controlPlaneService.AddEnvironmentAsync(command.DesiredState, cancellationToken);
 
-			return new ProvisioningBrokerResponse("{}");
+			return new ProvisioningBrokerResponse(aggregate);
 		}
 	}
 }

--- a/src/ResourceProvisioning.Broker.Application/Commands/Environment/GetEnvironmentCommandHandler.cs
+++ b/src/ResourceProvisioning.Broker.Application/Commands/Environment/GetEnvironmentCommandHandler.cs
@@ -18,12 +18,11 @@ namespace ResourceProvisioning.Broker.Application.Commands.Environment
 			_controlPlaneService = controlPlaneService ?? throw new ArgumentNullException(nameof(controlPlaneService));
 		}
 
-		public override async Task<IProvisioningResponse> Handle(GetEnvironmentCommand command, CancellationToken cancellationToken)
+		public override async Task<IProvisioningResponse> Handle(GetEnvironmentCommand command, CancellationToken cancellationToken = default)
 		{
-			//TODO: Re-enable GetEnvironmentCommandHandler logic once db is working. (Ch2943)
-			//var aggregate = await _controlPlaneService.GetEnvironmentByIdAsync(command.EnvironmentId);
+			var aggregate = await _controlPlaneService.GetEnvironmentByIdAsync(command.EnvironmentId);
 
-			return new ProvisioningBrokerResponse("{}");
+			return new ProvisioningBrokerResponse(aggregate);
 		}
 	}
 }

--- a/src/ResourceProvisioning.Broker.Host.Api/Controllers/V1/ControlPlaneController.cs
+++ b/src/ResourceProvisioning.Broker.Host.Api/Controllers/V1/ControlPlaneController.cs
@@ -26,10 +26,17 @@ namespace ResourceProvisioning.Broker.Host.Api.Controllers.V1
 		[HttpGet]
 		public async Task<IActionResult> Get()
 		{
-			//TODO: Finalize Get method on ControlPlaneController. (Ch3022)
-			var cmd = new GetEnvironmentCommand(Guid.Empty);
+			try
+			{
+				//TODO: Finalize Get method on ControlPlaneController. (Ch3022)
+				var cmd = new GetEnvironmentCommand(Guid.Empty);
 
-			return Ok(await _broker.Handle(cmd));
+				return Ok(await _broker.Handle(cmd));
+			}
+			catch (Exception e)
+			{
+				return BadRequest(e);
+			}
 		}
 
 		[Authorize(AuthenticationSchemes = AzureADDefaults.JwtBearerAuthenticationScheme)]

--- a/src/ResourceProvisioning.Broker.Host.Worker/appsettings.json
+++ b/src/ResourceProvisioning.Broker.Host.Worker/appsettings.json
@@ -6,6 +6,6 @@
 	},
 	"AllowedHosts": "*",
 	"ConnectionStrings": {
-		"DomainContext": "Data Source=:memory:;Version=3;New=True;"
+		"DomainContext": "Filename=:memory:;"
 	}
 }

--- a/src/ResourceProvisioning.Broker.Infrastructure/EntityFramework/DomainContext.cs
+++ b/src/ResourceProvisioning.Broker.Infrastructure/EntityFramework/DomainContext.cs
@@ -22,9 +22,9 @@ namespace ResourceProvisioning.Broker.Infrastructure.EntityFramework
 
 		public IDbContextTransaction GetCurrentTransaction { get; private set; }
 
-		public DomainContext() : this(new DbContextOptions<DomainContext>() { }, null) { }
+		public DomainContext() : this(new DbContextOptions<DomainContext>() { }, new FakeMediator()) { }
 
-		public DomainContext(DbContextOptions<DomainContext> options, IMediator mediator) : base(options)
+		public DomainContext(DbContextOptions options, IMediator mediator) : base(options)
 		{
 			_mediator = mediator;
 

--- a/src/ResourceProvisioning.Broker.Infrastructure/EntityFramework/DomainDesignFactory.cs
+++ b/src/ResourceProvisioning.Broker.Infrastructure/EntityFramework/DomainDesignFactory.cs
@@ -21,7 +21,7 @@ namespace ResourceProvisioning.Broker.Infrastructure.EntityFramework
 			var optionsBuilder = new DbContextOptionsBuilder<DomainContext>()
 				.UseSqlite(CreateDatabaseConnection(config.GetConnectionString(nameof(DomainContext))));
 
-			return new DomainContext(optionsBuilder.Options, new NoMediator());
+			return new DomainContext(optionsBuilder.Options, new FakeMediator());
 		}
 
 		private static DbConnection CreateDatabaseConnection(string connectionString)

--- a/src/ResourceProvisioning.Broker.Infrastructure/EntityFramework/FakeMediator.cs
+++ b/src/ResourceProvisioning.Broker.Infrastructure/EntityFramework/FakeMediator.cs
@@ -5,7 +5,7 @@ using MediatR;
 
 namespace ResourceProvisioning.Broker.Infrastructure.EntityFramework
 {
-	internal class NoMediator : IMediator
+	public class FakeMediator : IMediator
 	{
 		public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default) where TNotification : INotification
 		{


### PR DESCRIPTION
…ion is closed by registering a global singleton our DI container to ensure the DB is created and available for as long as our process is alive (this is quick and dirty, but it works)